### PR TITLE
WIP: temp facebook user-agent fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ RUN if [ ${DISCORD_ENABLED} -eq 1 ]; then cd /tmp && \
 # Facebook #
 ############
 ARG FACEBOOK_ENABLED=1
-ARG FACEBOOK_TAG=master
+ARG FACEBOOK_TAG=fix_login
 RUN if [ ${FACEBOOK_ENABLED} -eq 1 ]; then cd /tmp && \
     apk add --no-cache --update --virtual facebook-run-deps \
 	    json-glib && \
@@ -123,7 +123,7 @@ RUN if [ ${FACEBOOK_ENABLED} -eq 1 ]; then cd /tmp && \
 	    libtool \
 	    glib-dev \
 	    json-glib-dev && \
-	git clone -n https://github.com/bitlbee/bitlbee-facebook.git && \
+	git clone -n https://github.com/gmartsenkov/bitlbee-facebook.git && \
 	cd bitlbee-facebook && \
 	git checkout ${FACEBOOK_TAG} && \
 	./autogen.sh \

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker build -t docker-alpine-bitlbee . \
   --build-arg ROCKETCHAT_ENABLED=0 \
   --build-arg MATRIX_ENABLED=0 \
   --build-arg MATTERMOST_ENABLED=0 \
-  --build-arg MASTODON_ENABLED=0 \
+  --build-arg MASTODON_ENABLED=0
 ```
 
 Running


### PR DESCRIPTION
Temp fix for the FB user-agent issue that is still unresolved upstream.

See:
- https://github.com/vantaworks/docker-alpine-bitlbee/issues/4
- https://github.com/bitlbee/bitlbee-facebook/issues/195

The _fix_ here is looking at a PR instead of the main repo:
- https://github.com/bitlbee/bitlbee-facebook/pull/213

I did upload the resulting Docker image to DockerHub under the `uafix` tag:
- https://hub.docker.com/r/thisisvantaworks/alpine-bitlbee/tags
- `docker pull thisisvantaworks/alpine-bitlbee:uafix`